### PR TITLE
Improve speckit skill docs

### DIFF
--- a/skills/speckit-analyze/SKILL.md
+++ b/skills/speckit-analyze/SKILL.md
@@ -25,7 +25,7 @@ Identify inconsistencies, duplications, ambiguities, and underspecified items ac
 
 **Constitution Authority**: The project constitution (`.specify/memory/constitution.md`) is **non-negotiable** within this analysis scope. Constitution conflicts are automatically CRITICAL and require adjustment of the spec, plan, or tasks—not dilution, reinterpretation, or silent ignoring of the principle. If a principle itself needs to change, that must occur in a separate, explicit constitution update outside this skill.
 
-## Execution Steps
+## Workflow
 
 ### 1. Initialize Analysis Context
 
@@ -166,6 +166,10 @@ At end of report, output a concise Next Actions block:
 ### 8. Offer Remediation
 
 Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
+
+## Outputs
+
+- Read-only analysis report in the response (no file writes)
 
 ## Operating Principles
 

--- a/skills/speckit-checklist/SKILL.md
+++ b/skills/speckit-checklist/SKILL.md
@@ -37,7 +37,7 @@ If the request is empty or unclear, ask a targeted question before continuing.
 
 **Metaphor**: If your spec is code written in English, the checklist is its unit test suite. You're testing whether the requirements are well-written, complete, unambiguous, and ready for implementation - NOT whether the implementation works.
 
-## Execution Steps
+## Workflow
 
 1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS list.
    - All file paths must be absolute.
@@ -298,3 +298,7 @@ Sample items:
 - Correct: Validation of requirement quality
 - Wrong: "Does it do X?"
 - Correct: "Is X clearly specified?"
+
+## Outputs
+
+- `specs/<feature>/checklists/<domain>.md` (new checklist file per run)

--- a/skills/speckit-clarify/SKILL.md
+++ b/skills/speckit-clarify/SKILL.md
@@ -181,3 +181,13 @@ Behavior rules:
 - If quota reached with unresolved high-impact categories remaining, explicitly flag them under Deferred with rationale.
 
 Context for prioritization: the user's request and any stated constraints
+
+## Outputs
+
+- Updated `specs/<feature>/spec.md` with clarifications appended and integrated
+
+## Next Steps
+
+After clarifications are resolved:
+
+- **Plan** implementation with speckit-plan.

--- a/skills/speckit-constitution/SKILL.md
+++ b/skills/speckit-constitution/SKILL.md
@@ -88,3 +88,14 @@ If the user supplies partial updates (e.g., only one principle revision), still 
 If critical info missing (e.g., ratification date truly unknown), insert `TODO(<FIELD_NAME>): explanation` and include in the Sync Impact Report under deferred items.
 
 Do not create a new template; always operate on the existing `.specify/memory/constitution.md` file.
+
+## Outputs
+
+- Updated `.specify/memory/constitution.md` (with Sync Impact Report comment)
+- Any updated templates or runtime guidance files required to stay consistent with the constitution
+
+## Next Steps
+
+After updating the constitution:
+
+- **Specify** new features with speckit-specify.

--- a/skills/speckit-implement/SKILL.md
+++ b/skills/speckit-implement/SKILL.md
@@ -140,3 +140,9 @@ If tasks are missing or incomplete, ask the user to run speckit-tasks first.
    - Report final status with summary of completed work
 
 Note: This skill assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running speckit-tasks first to regenerate the task list.
+
+## Outputs
+
+- Implementation changes in the codebase
+- Updated `specs/<feature>/tasks.md` with completed tasks checked off
+- Any generated/updated ignore files (e.g., `.gitignore`, `.dockerignore`, `.eslintignore`, `.prettierignore`)

--- a/skills/speckit-plan/SKILL.md
+++ b/skills/speckit-plan/SKILL.md
@@ -86,3 +86,19 @@ If the spec is missing, ask the user to run speckit-specify first.
 
 - Use absolute paths
 - ERROR on gate failures or unresolved clarifications
+
+## Outputs
+
+- `specs/<feature>/plan.md` (filled implementation plan)
+- `specs/<feature>/research.md`
+- `specs/<feature>/data-model.md`
+- `specs/<feature>/contracts/` (API schemas)
+- `specs/<feature>/quickstart.md`
+- Updated agent context file (runtime-specific)
+
+## Next Steps
+
+After planning:
+
+- **Generate tasks** with speckit-tasks.
+- **Create a checklist** with speckit-checklist when a quality gate is needed.

--- a/skills/speckit-specify/SKILL.md
+++ b/skills/speckit-specify/SKILL.md
@@ -190,6 +190,19 @@ Given that feature description, do this:
 
 **NOTE:** The script creates and checks out the new branch and initializes the spec file before writing.
 
+## Outputs
+
+- `specs/<feature>/spec.md`
+- `specs/<feature>/checklists/requirements.md`
+- New feature branch created by `.specify/scripts/bash/create-new-feature.sh`
+
+## Next Steps
+
+After generating the spec:
+
+- **Clarify** requirements with speckit-clarify.
+- **Plan** implementation with speckit-plan.
+
 ## General Guidelines
 
 ## Quick Guidelines

--- a/skills/speckit-tasks/SKILL.md
+++ b/skills/speckit-tasks/SKILL.md
@@ -133,3 +133,14 @@ Every task MUST strictly follow this format:
   - Within each story: Tests (if requested) → Models → Services → Endpoints → Integration
   - Each phase should be a complete, independently testable increment
 - **Final Phase**: Polish & Cross-Cutting Concerns
+
+## Outputs
+
+- `specs/<feature>/tasks.md`
+
+## Next Steps
+
+After tasks are generated:
+
+- **Analyze** cross-artifact consistency with speckit-analyze.
+- **Implement** the plan with speckit-implement.

--- a/skills/speckit-taskstoissues/SKILL.md
+++ b/skills/speckit-taskstoissues/SKILL.md
@@ -36,3 +36,7 @@ git config --get remote.origin.url
 
 > [!CAUTION]
 > UNDER NO CIRCUMSTANCES EVER CREATE ISSUES IN REPOSITORIES THAT DO NOT MATCH THE REMOTE URL
+
+## Outputs
+
+- GitHub issues created from `tasks.md` (one per task), in the repository matching the Git remote


### PR DESCRIPTION
## Summary
- add Outputs/Next Steps sections to speckit skills for consistent converter structure
- align headings with the standard Workflow terminology

## Testing
- not run (doc-only changes)